### PR TITLE
chore: add gomplate CVE-2022-41721 to ignorelist

### DIFF
--- a/base/.trivyignore
+++ b/base/.trivyignore
@@ -2,6 +2,8 @@
 # gomplate
 # Not affected: https://github.com/hairyhenderson/gomplate/issues/1533
 CVE-2022-32149
+# Not affected: https://github.com/hairyhenderson/gomplate/issues/1608
+CVE-2022-41721
 # guzzlehttp/guzzle
 # These CVE's are related to oC 10.10 core. As long as we build this version,
 # we need to ignore it in trivy.


### PR DESCRIPTION
Affected component `net/http2` not used by gomplate.