### PR TITLE
Add CVE-2023-29197 to .trivyignore

### DIFF
--- a/base/.trivyignore
+++ b/base/.trivyignore
@@ -17,3 +17,4 @@ CVE-2021-46743
 # These CVE's are related to oC 10.11 core. As long as we build this version,
 # we need to ignore it in trivy.
 CVE-2023-27560
+CVE-2023-29197


### PR DESCRIPTION
Because it effects old release 10.11 (but not 10.12).

See discussion in https://github.com/owncloud-docker/server/pull/395