### PR TITLE
Remove CVEs related to oC core 10.10

### DIFF
--- a/base/.trivyignore
+++ b/base/.trivyignore
@@ -4,16 +4,6 @@
 CVE-2022-32149
 # Not affected: https://github.com/hairyhenderson/gomplate/issues/1608
 CVE-2022-41721
-# These CVE's are related to oC 10.10 core. As long as we build this version,
-# we need to ignore it in trivy.
-## guzzlehttp/guzzle
-CVE-2022-29248
-CVE-2022-31042
-CVE-2022-31043
-CVE-2022-31090
-CVE-2022-31091
-## firebase/php-jwt
-CVE-2021-46743
 # These CVE's are related to oC 10.11 core. As long as we build this version,
 # we need to ignore it in trivy.
 CVE-2023-27560


### PR DESCRIPTION
We don't build oC core 10.10 any more in https://github.com/owncloud-docker/server
Delete the entries from `.trivyignore`
The benefit will be that those CVEs are checked when we run Trivy with oC core 10.11 10.12 etc.